### PR TITLE
Implement CopyFromRemote for io.Reader filesink

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,13 +9,14 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"golang.org/x/crypto/ssh"
 	"io"
 	"io/ioutil"
 	"os"
 	"path"
 	"sync"
 	"time"
+
+	"golang.org/x/crypto/ssh"
 )
 
 type Client struct {
@@ -64,25 +65,94 @@ func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 		defer close(c)
 		wg.Wait()
 	}()
-	select {
-	case <-c:
-		return false // completed normally
-	case <-time.After(timeout):
-		return true // timed out
+
+	for {
+		select {
+		case <-c:
+			return false // completed normally
+		case <-time.After(timeout):
+			if timeout.Nanoseconds() == 0 {
+				continue
+			}
+			return true // timed out
+		}
 	}
+
+}
+
+// CopyFromRemote copies the contents of a remote file into an io.Reader
+func (a *Client) CopyFromRemote(remotePath string) (io.Reader, int, error) {
+	errCh := make(chan error, 2)
+
+	c := &Command{}
+	readerCh := make(chan io.Reader, 1)
+
+	r, _, w, err := pipes(a.Session)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	prepReader := func(wg *sync.WaitGroup) {
+		defer wg.Done()
+		defer w.Close()
+
+		err = readCommand(r, w, c)
+		if err != nil && err != io.EOF {
+			errCh <- err
+			return
+		}
+
+		// prep to recieve
+		_, err = w.Write([]byte{0})
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		// redirect our reader
+		readerCh <- r
+	}
+
+	syncFile := func(wg *sync.WaitGroup) {
+		defer wg.Done()
+
+		// start the transfer (and ignore error codes)
+		a.Session.Run("/usr/bin/scp -qf " + remotePath)
+	}
+
+	wg := a.scpFunc(prepReader, syncFile, errCh, 2)
+
+	if waitTimeout(wg, a.Timeout) {
+		return nil, 0, errors.New("timeout when downloading files")
+	}
+
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+
+	return <-readerCh, c.Permissions, nil
 }
 
 // Copies the contents of an io.Reader to a remote location
 func (a *Client) Copy(r io.Reader, remotePath string, permissions string, size int64) error {
 	filename := path.Base(remotePath)
 	directory := path.Dir(remotePath)
-
-	wg := sync.WaitGroup{}
-	wg.Add(2)
-
 	errCh := make(chan error, 2)
 
-	go func() {
+	syncFile := func(wg *sync.WaitGroup) {
+		defer wg.Done()
+
+		err := a.Session.Run("/usr/bin/scp -qt " + directory)
+		if err != nil {
+			errCh <- err
+			return
+		}
+	}
+
+	copyFile := func(wg *sync.WaitGroup) {
 		defer wg.Done()
 		w, err := a.Session.StdinPipe()
 		if err != nil {
@@ -108,18 +178,11 @@ func (a *Client) Copy(r io.Reader, remotePath string, permissions string, size i
 			errCh <- err
 			return
 		}
-	}()
+	}
 
-	go func() {
-		defer wg.Done()
-		err := a.Session.Run("/usr/bin/scp -qt " + directory)
-		if err != nil {
-			errCh <- err
-			return
-		}
-	}()
+	wg := a.scpFunc(copyFile, syncFile, errCh, 2)
 
-	if waitTimeout(&wg, a.Timeout) {
+	if waitTimeout(wg, a.Timeout) {
 		return errors.New("timeout when upload files")
 	}
 	close(errCh)
@@ -134,4 +197,78 @@ func (a *Client) Copy(r io.Reader, remotePath string, permissions string, size i
 func (a *Client) Close() {
 	a.Session.Close()
 	a.Conn.Close()
+}
+
+func (a *Client) scpFunc(fileFunc func(*sync.WaitGroup), syncFunc func(*sync.WaitGroup), errCh chan error, wgSize int) *sync.WaitGroup {
+	wg := sync.WaitGroup{}
+	wg.Add(wgSize)
+
+	go func() {
+		fileFunc(&wg)
+	}()
+
+	go func() {
+		syncFunc(&wg)
+	}()
+
+	return &wg
+}
+
+// readCommand readies a buffer and initiates listening for an SCP command, and returns
+// the Command when parsed. w is not closed by readCommand
+func readCommand(r io.Reader, w io.WriteCloser, c *Command) error {
+	// recieve remote command input
+	buf := bytes.Buffer{}
+
+	// write a null byte to signal we are ready to receive data
+	_, err := w.Write([]byte{0})
+	if err != nil && err != io.EOF {
+		return err
+	}
+
+	for {
+		cmd := make([]byte, 64)
+		_, err := r.Read(cmd)
+		if err != nil && err != io.EOF {
+			return err
+		} else if err == io.EOF {
+			break
+		}
+
+		if string(cmd) == "" {
+			continue
+		}
+		_, err = buf.Write(cmd)
+		if err != nil {
+			return err
+		}
+
+		err = c.UnmarshalText(buf.Bytes())
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return errors.New("no scp cmd found")
+}
+
+func pipes(s *ssh.Session) (io.Reader, io.Reader, io.WriteCloser, error) {
+	w, err := s.StdinPipe()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	r, err := s.StdoutPipe()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	e, err := s.StderrPipe()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return r, e, w, err
 }

--- a/client.go
+++ b/client.go
@@ -81,7 +81,7 @@ func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 }
 
 // CopyFromRemote copies the contents of a remote file into an io.Reader
-func (a *Client) CopyFromRemote(remotePath string) (io.Reader, int, error) {
+func (a *Client) CopyFromRemote(remotePath string) (io.Reader, os.FileMode, error) {
 	errCh := make(chan error, 2)
 
 	c := &Command{}

--- a/client.go
+++ b/client.go
@@ -142,6 +142,16 @@ func (a *Client) Copy(r io.Reader, remotePath string, permissions string, size i
 	directory := path.Dir(remotePath)
 	errCh := make(chan error, 2)
 
+	c, err := NewCommand(permissions, filename, uint64(size))
+	if err != nil {
+		return err
+	}
+
+	scpCmd, err := c.MarshalText()
+	if err != nil {
+		return err
+	}
+
 	syncFile := func(wg *sync.WaitGroup) {
 		defer wg.Done()
 
@@ -161,7 +171,7 @@ func (a *Client) Copy(r io.Reader, remotePath string, permissions string, size i
 		}
 		defer w.Close()
 
-		_, err = fmt.Fprintln(w, "C"+permissions, size, filename)
+		_, err = fmt.Fprintln(w, string(scpCmd))
 		if err != nil {
 			errCh <- err
 			return

--- a/command.go
+++ b/command.go
@@ -1,0 +1,50 @@
+package scp
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Command represents a SCP command sent to or from the remote system
+type Command struct {
+	Permissions int
+	Size        uint
+	Filename    string
+}
+
+// MarshalText implements the TextMarshaler interface
+func (c *Command) MarshalText() (text []byte, err error) {
+	perms := strconv.Itoa(c.Permissions)
+	size := strconv.Itoa(int(c.Size))
+
+	return []byte(fmt.Sprintf("C%s %s %s", perms, size, c.Filename)), nil
+}
+
+// UnmarshalText implements the TextUnmarshaler interface
+func (c *Command) UnmarshalText(text []byte) error {
+	cmd := string(text)
+	parts := strings.Split(strings.Trim(cmd, "\n\x00"), " ")
+
+	if len(parts) != 3 {
+		return fmt.Errorf("Command '%s' invalid", cmd)
+	}
+
+	perms, err := strconv.Atoi(parts[0][1:])
+	if err != nil {
+		return err
+	}
+
+	size, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return err
+	}
+
+	*c = Command{
+		Permissions: perms,
+		Size:        uint(size),
+		Filename:    parts[2],
+	}
+
+	return nil
+}

--- a/command.go
+++ b/command.go
@@ -10,8 +10,21 @@ import (
 // Command represents a SCP command sent to or from the remote system
 type Command struct {
 	Permissions os.FileMode
-	Size        uint
+	Size        uint64
 	Filename    string
+}
+
+func NewCommand(permissions, filename string, size uint64) (*Command, error) {
+	p, err := strconv.ParseInt(permissions, 8, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Command{
+		Permissions: os.FileMode(p),
+		Filename:    filename,
+		Size:        size,
+	}, nil
 }
 
 // MarshalText implements the TextMarshaler interface
@@ -45,7 +58,7 @@ func (c *Command) UnmarshalText(text []byte) error {
 
 	*c = Command{
 		Permissions: os.FileMode(perms),
-		Size:        uint(size),
+		Size:        uint64(size),
 		Filename:    parts[2],
 	}
 

--- a/command_test.go
+++ b/command_test.go
@@ -1,0 +1,143 @@
+package scp
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestCommand_Marshal(t *testing.T) {
+	tests := map[string]struct {
+		perms  os.FileMode
+		size   uint
+		name   string
+		assert string
+		err    error
+	}{
+		"full permissions": {
+			perms:  os.ModePerm,
+			size:   42,
+			name:   "test",
+			assert: "C0777 42 test",
+		},
+		"bad permissions": {
+			perms: 21312,
+			size:  42,
+			name:  "test",
+			err:   fmt.Errorf("bad permissions %o (0%d)", 21312, 21312),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := Command{
+				Permissions: tc.perms,
+				Size:        tc.size,
+				Filename:    tc.name,
+			}
+
+			ct, err := c.MarshalText()
+			checkErr(t, err, tc.err)
+
+			if string(ct) != tc.assert {
+				t.Errorf("%s != %s", ct, tc.assert)
+			}
+		})
+	}
+}
+
+func TestCommand_Unarshal(t *testing.T) {
+	tests := map[string]struct {
+		text   string
+		assert Command
+		err    error
+	}{
+		"full permissions": {
+			text: "C0777 42 test",
+			assert: Command{
+				Permissions: os.ModePerm,
+				Size:        42,
+				Filename:    "test",
+			},
+		},
+		"invalid command": {
+			text: "C0777 42 test extra",
+			err:  fmt.Errorf("Command 'C0777 42 test extra' is invalid"),
+		},
+		"bad permissions command": {
+			text: "C2853 42 test",
+			err:  fmt.Errorf("strconv.ParseInt: parsing \"2853\": invalid syntax"),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := &Command{}
+			err := c.UnmarshalText([]byte(tc.text))
+			if checkErr(t, err, tc.err) {
+				return
+			}
+
+		})
+	}
+}
+
+func checkErr(t *testing.T, err, caseErr error) (checkedErr bool) {
+	if err != nil && caseErr == nil {
+		t.Errorf("failed with error: %s", err)
+	}
+	if err != nil && caseErr != nil {
+		if err.Error() != caseErr.Error() {
+			t.Errorf("unmatched errors: %s != %s", err, caseErr)
+		}
+
+		return true
+	}
+
+	return false
+}
+
+func TestCommand_New(t *testing.T) {
+	tests := map[string]struct {
+		perms  string
+		size   uint
+		name   string
+		assert string
+		err    error
+	}{
+		"full permissions": {
+			perms:  "777",
+			size:   42,
+			name:   "test",
+			assert: "C0777 42 test",
+		},
+		"bad parse": {
+			perms: "779",
+			size:  42,
+			name:  "test",
+			err:   fmt.Errorf("strconv.ParseInt: parsing \"779\": invalid syntax"),
+		},
+		"bad permissions": {
+			perms: "21323",
+			size:  42,
+			name:  "test",
+			err:   fmt.Errorf("bad permissions 21323 (08915)"),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			c, err := NewCommand(tc.perms, tc.name, tc.size)
+			if checkErr(t, err, tc.err) {
+				return
+			}
+
+			ct, err := c.MarshalText()
+			checkErr(t, err, tc.err)
+
+			if string(ct) != tc.assert {
+				t.Errorf("%s != %s", ct, tc.assert)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces CopyFromRemote (from #1) which returns an `io.Reader` with the file contents, the remote file permissions (as an int) and an error if it occurred.

Closes #1