### PR TITLE
Remove extraneous slash from docs

### DIFF
--- a/scp.go
+++ b/scp.go
@@ -33,7 +33,7 @@ func NewClientBySSH(ssh *ssh.Client) (Client, error) {
 	return NewConfigurer("", nil).Session(session).Create(), nil
 }
 
-/// Same as NewClientWithTimeout but uses an existing SSH client
+// Same as NewClientWithTimeout but uses an existing SSH client
 func NewClientBySSHWithTimeout(ssh *ssh.Client, timeout time.Duration) (Client, error) {
 	session, err := ssh.NewSession()
 	if err != nil {


### PR DESCRIPTION
Documentation for the [`NewClientBySSHWithTimeout()` function](https://pkg.go.dev/github.com/bramvdbogaerde/go-scp#NewClientBySSHWithTimeout) currently looks like that:

>/ Same as NewClientWithTimeout but uses an existing SSH client

It would be nice if it would look like this instead:

>Same as NewClientWithTimeout but uses an existing SSH client