### PR TITLE
Use ssh.ClientConfig.Timeout for Configurer

### DIFF
--- a/configurer.go
+++ b/configurer.go
@@ -33,7 +33,7 @@ func NewConfigurer(host string, config *ssh.ClientConfig) *ClientConfigurer {
 	return &ClientConfigurer{
 		host:         host,
 		clientConfig: config,
-		timeout:      time.Minute,
+		timeout:      config.Timeout,
 		remoteBinary: "scp",
 	}
 }


### PR DESCRIPTION
Before this commit `NewConfigurer` assigns a `time.Minute` duration for timeout and uses this value in `Create` method thus the caller cannot set `timeout` before creating a `Client` and caller is forced to set `timeout` after creating `Client`.
This commit fixes this issue and doesn't break any functionality or API.