### PR TITLE
Run `gofmt -w .`

### DIFF
--- a/client.go
+++ b/client.go
@@ -206,13 +206,13 @@ func (a *Client) CopyPassThru(r io.Reader, remotePath string, permissions string
 }
 
 // Copy a file from the remote to the local file given by the `file`
-// parameter. Use `CopyFromRemotePassThru` if a more generic writer 
+// parameter. Use `CopyFromRemotePassThru` if a more generic writer
 // is desired instead of writing directly to a file on the file system.?
 func (a *Client) CopyFromRemote(file *os.File, remotePath string) error {
 	return a.CopyFromRemotePassThru(file, remotePath, nil)
 }
 
-// Copy a file from the remote to the given writer. The passThru parameter can be used 
+// Copy a file from the remote to the given writer. The passThru parameter can be used
 // to keep track of progress and how many bytes that were download from the remote.
 // `passThru` can be set to nil to disable this behaviour.
 func (a *Client) CopyFromRemotePassThru(w io.Writer, remotePath string, passThru PassThru) error {
@@ -227,50 +227,50 @@ func (a *Client) CopyFromRemotePassThru(w io.Writer, remotePath string, passThru
 			if err != nil {
 				errCh <- err
 			}
-                        errCh<-err
+			errCh <- err
 			wg.Done()
 		}()
 
 		r, err := a.Session.StdoutPipe()
 		if err != nil {
-                        errCh<-err
+			errCh <- err
 			return
 		}
 
 		in, err := a.Session.StdinPipe()
 		if err != nil {
-                        errCh<-err
+			errCh <- err
 			return
 		}
 		defer in.Close()
 
 		err = a.Session.Start(fmt.Sprintf("%s -f %s", a.RemoteBinary, remotePath))
 		if err != nil {
-                        errCh<-err
+			errCh <- err
 			return
 		}
 
 		err = Ack(in)
 		if err != nil {
-                        errCh<-err
+			errCh <- err
 			return
 		}
 
 		res, err := ParseResponse(r)
 		if err != nil {
-                        errCh<-err
+			errCh <- err
 			return
 		}
 
 		infos, err := res.ParseFileInfos()
 		if err != nil {
-                        errCh<-err
+			errCh <- err
 			return
 		}
 
 		err = Ack(in)
 		if err != nil {
-                        errCh<-err
+			errCh <- err
 			return
 		}
 
@@ -280,19 +280,19 @@ func (a *Client) CopyFromRemotePassThru(w io.Writer, remotePath string, passThru
 
 		_, err = CopyN(w, r, infos.Size)
 		if err != nil {
-                        errCh<-err
+			errCh <- err
 			return
 		}
 
 		err = Ack(in)
 		if err != nil {
-                        errCh<-err
+			errCh <- err
 			return
 		}
 
 		err = a.Session.Wait()
 		if err != nil {
-                        errCh<-err
+			errCh <- err
 			return
 		}
 	}()

--- a/protocol.go
+++ b/protocol.go
@@ -110,7 +110,7 @@ func (r *Response) ParseFileInfos() (*FileInfos, error) {
 	}, nil
 }
 
-// Writes an `Ack` message to the remote, does not await its response, a seperate call to ParseResponse is 
+// Writes an `Ack` message to the remote, does not await its response, a seperate call to ParseResponse is
 // therefore required to check if the acknowledgement succeeded
 func Ack(writer io.Writer) error {
 	var msg = []byte{0}

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -1,110 +1,109 @@
 package tests
 
-import(
-   "testing"
-   "io/ioutil"
-   "strings"
-   "golang.org/x/crypto/ssh"
-   "os"
-   scp "github.com/bramvdbogaerde/go-scp"
-   "github.com/bramvdbogaerde/go-scp/auth"
+import (
+	scp "github.com/bramvdbogaerde/go-scp"
+	"github.com/bramvdbogaerde/go-scp/auth"
+	"golang.org/x/crypto/ssh"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
 )
 
 // This test, tests the basic functionality of the library: copying files
-// it assumes that a docker container is running an SSH server at port 
+// it assumes that a docker container is running an SSH server at port
 // 2244 using password authentication.
 //
 // It also assumes that the directory /results is writable within that container
-// and is mapped to the tmp/ directory within this directory. 
+// and is mapped to the tmp/ directory within this directory.
 func TestCopy(t *testing.T) {
-   // Use SSH key authentication from the auth package
-   // we ignore the host key in this example, please change this if you use this library
-   clientConfig, _ := auth.PasswordKey("bram", "test", ssh.InsecureIgnoreHostKey())
+	// Use SSH key authentication from the auth package
+	// we ignore the host key in this example, please change this if you use this library
+	clientConfig, _ := auth.PasswordKey("bram", "test", ssh.InsecureIgnoreHostKey())
 
-   // For other authentication methods see ssh.ClientConfig and ssh.AuthMethod
+	// For other authentication methods see ssh.ClientConfig and ssh.AuthMethod
 
-   // Create a new SCP client
-   client := scp.NewClient("127.0.0.1:2244", &clientConfig)
+	// Create a new SCP client
+	client := scp.NewClient("127.0.0.1:2244", &clientConfig)
 
-   // Connect to the remote server
-   err := client.Connect()
-   if err != nil {
-            t.Errorf("Couldn't establish a connection to the remote server %s", err)
-            return
-   }
+	// Connect to the remote server
+	err := client.Connect()
+	if err != nil {
+		t.Errorf("Couldn't establish a connection to the remote server %s", err)
+		return
+	}
 
-   // Open a file
-   f, _ := os.Open("./input.txt")
+	// Open a file
+	f, _ := os.Open("./input.txt")
 
-   // Close client connection after the file has been copied
-   defer client.Close()
+	// Close client connection after the file has been copied
+	defer client.Close()
 
-   // Close the file after it has been copied
-   defer f.Close()
+	// Close the file after it has been copied
+	defer f.Close()
 
-   // Finaly, copy the file over
-   // Usage: CopyFile(fileReader, remotePath, permission)
+	// Finaly, copy the file over
+	// Usage: CopyFile(fileReader, remotePath, permission)
 
-   err = client.CopyFile(f, "/data/output.txt", "0655")
+	err = client.CopyFile(f, "/data/output.txt", "0655")
 
-   if err != nil {
-            t.Errorf("Error while copying file %s", err)
-   }
+	if err != nil {
+		t.Errorf("Error while copying file %s", err)
+	}
 
-   content, err := ioutil.ReadFile("./tmp/output.txt")
-   if err != nil {
-            t.Errorf("Test has failed, file could not be opened")
-   }
+	content, err := ioutil.ReadFile("./tmp/output.txt")
+	if err != nil {
+		t.Errorf("Test has failed, file could not be opened")
+	}
 
-   text := string(content)
-   expected := "It Works\n"
-   if strings.Compare(text, expected) != 0 {
-            t.Errorf("Got different text than expected, expected \"%s\" got, \"%s\"", expected, text)
-   }
+	text := string(content)
+	expected := "It Works\n"
+	if strings.Compare(text, expected) != 0 {
+		t.Errorf("Got different text than expected, expected \"%s\" got, \"%s\"", expected, text)
+	}
 }
 
-// This test assumes that a Docker container is running that has the SCP binary available 
+// This test assumes that a Docker container is running that has the SCP binary available
 // and exposes an SSH server on port 2244 using password authentication.
 //
 // The test checks whether it can retrieve a file from the remote and checks the file against the expected file
 func TestDownloadFile(t *testing.T) {
-   // Use SSH key authentication from the auth package
-   // we ignore the host key in this example, please change this if you use this library
-   clientConfig, _ := auth.PasswordKey("bram", "test", ssh.InsecureIgnoreHostKey())
+	// Use SSH key authentication from the auth package
+	// we ignore the host key in this example, please change this if you use this library
+	clientConfig, _ := auth.PasswordKey("bram", "test", ssh.InsecureIgnoreHostKey())
 
-   // For other authentication methods see ssh.ClientConfig and ssh.AuthMethod
+	// For other authentication methods see ssh.ClientConfig and ssh.AuthMethod
 
-   // Create a new SCP client
-   client := scp.NewClient("127.0.0.1:2244", &clientConfig)
+	// Create a new SCP client
+	client := scp.NewClient("127.0.0.1:2244", &clientConfig)
 
-   // Connect to the remote server
-   err := client.Connect()
-   if err != nil {
-            t.Errorf("Couldn't establish a connection to the remote server %s", err)
-            return
-   }
+	// Connect to the remote server
+	err := client.Connect()
+	if err != nil {
+		t.Errorf("Couldn't establish a connection to the remote server %s", err)
+		return
+	}
 
-   f, err := os.OpenFile("./tmp/output.txt", os.O_RDWR|os.O_CREATE, 0755)
-   if err != nil {
-      t.Errorf("Couldn't open the output file")
-   }
+	f, err := os.OpenFile("./tmp/output.txt", os.O_RDWR|os.O_CREATE, 0755)
+	if err != nil {
+		t.Errorf("Couldn't open the output file")
+	}
 
-   // Close client connection after the file has been copied
-   defer client.Close()
+	// Close client connection after the file has been copied
+	defer client.Close()
 
-   // Close the file after it has been copied
-   defer f.Close()
+	// Close the file after it has been copied
+	defer f.Close()
 
+	err = client.CopyFromRemote(f, "/input/test_download.txt")
+	if err != nil {
+		t.Errorf("Copy failed from remote")
+	}
 
-   err = client.CopyFromRemote(f, "/input/test_download.txt");
-   if err != nil {
-         t.Errorf("Copy failed from remote");
-   }
-
-   content, err := ioutil.ReadFile("./tmp/output.txt")
-   text := string(content)
-   expected := "It works for download!\n"
-   if strings.Compare(text, expected) != 0 {
-            t.Errorf("Got different text than expected, expected \"%s\" got, \"%s\"", expected, text)
-   }
+	content, err := ioutil.ReadFile("./tmp/output.txt")
+	text := string(content)
+	expected := "It works for download!\n"
+	if strings.Compare(text, expected) != 0 {
+		t.Errorf("Got different text than expected, expected \"%s\" got, \"%s\"", expected, text)
+	}
 }

--- a/utils.go
+++ b/utils.go
@@ -8,18 +8,18 @@ package scp
 
 import "io"
 
-// An adaptation of io.CopyN that keeps reading if it did not return 
+// An adaptation of io.CopyN that keeps reading if it did not return
 // a sufficient amount of bytes.
 func CopyN(writer io.Writer, src io.Reader, size int64) (int64, error) {
-        var total int64
-        total = 0
-        for total < size {
-           n, err := io.CopyN(writer, src, size)
-           if err != nil {
-              return 0, err
-           }
-           total += n
-        }
+	var total int64
+	total = 0
+	for total < size {
+		n, err := io.CopyN(writer, src, size)
+		if err != nil {
+			return 0, err
+		}
+		total += n
+	}
 
-        return total, nil
+	return total, nil
 }


### PR DESCRIPTION
This will run the official [Go formatter][1], in order to make sure
that the code is following the recommended standards for Go projects.

[1]: https://golang.org/cmd/gofmt/