### PR TITLE
update waitTimeout func

### DIFF
--- a/client.go
+++ b/client.go
@@ -97,10 +97,13 @@ func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 		wg.Wait()
 	}()
 	if timeout > 0 {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+
 		select {
 		case <-c:
 			return false // completed normally
-		case <-time.After(timeout):
+		case <-timer.C:
 			return true // timed out
 		}
 	} else {


### PR DESCRIPTION
* use a simple channel receive
* as the doc says "If efficiency is a concern, use NewTimer instead and call Timer.Stop if the timer is no longer needed."
---
The #48  was weird, I have not found a solution for it, so open a new one, please forgive me.
