### PR TITLE
Update README.md to use CopyFromFile instead of CopyFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ func main() {
 	defer f.Close()
 
 	// Finaly, copy the file over
-	// Usage: CopyFile(fileReader, remotePath, permission)
+	// Usage: CopyFromFile(file, remotePath, permission)
 
-	err = client.CopyFile(f, "/home/server/test.txt", "0655")
+	err = client.CopyFromFile(*f, "/home/server/test.txt", "0655")
 
 	if err != nil {
 		fmt.Println("Error while copying file ", err)


### PR DESCRIPTION
CopyFile copies the entire file into memory which is a huge footgun for a lot of applications. It caused my test machine to OOM several times before I figured it out. Might be good to modify CopyFile to automaically check if it's a file to avoid this issue all together