### PR TITLE
Use a context instead of timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.idea
+/vendor

--- a/configurer.go
+++ b/configurer.go
@@ -7,9 +7,8 @@
 package scp
 
 import (
-	"time"
-
 	"golang.org/x/crypto/ssh"
+	"time"
 )
 
 // A struct containing all the configuration options

--- a/scp.go
+++ b/scp.go
@@ -20,6 +20,7 @@ func NewClient(host string, config *ssh.ClientConfig) Client {
 }
 
 // Returns a new scp.Client with provides host, ssh.ClientConfig and timeout
+// Deprecated: provide meaningful context to each "Copy*" function instead.
 func NewClientWithTimeout(host string, config *ssh.ClientConfig, timeout time.Duration) Client {
 	return NewConfigurer(host, config).Timeout(timeout).Create()
 }
@@ -34,6 +35,7 @@ func NewClientBySSH(ssh *ssh.Client) (Client, error) {
 }
 
 // Same as NewClientWithTimeout but uses an existing SSH client
+// Deprecated: provide meaningful context to each "Copy*" function instead.
 func NewClientBySSHWithTimeout(ssh *ssh.Client, timeout time.Duration) (Client, error) {
 	session, err := ssh.NewSession()
 	if err != nil {

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -16,7 +16,7 @@ docker run -d \
    -v $(pwd)/entrypoint.d/:/etc/entrypoint.d/ \
    panubo/sshd
 
-sleep 2
+sleep 5
 
 echo "Running tests"
 go test


### PR DESCRIPTION
It will be nice to have an ability to use context for manipulating file copy process.