### PR TITLE
fix: CopyRemotePassThru blocked on writing to error channel

### DIFF
--- a/client.go
+++ b/client.go
@@ -241,11 +241,10 @@ func (a *Client) CopyFromRemotePassThru(ctx context.Context, w io.Writer, remote
 		var err error
 
 		defer func() {
-			if err != nil {
-				errCh <- err
-			}
-			errCh <- err
+			// We must unblock the go routine first as we block on reading the channel later
 			wg.Done()
+
+			errCh <- err
 		}()
 
 		r, err := a.Session.StdoutPipe()
@@ -323,9 +322,9 @@ func (a *Client) CopyFromRemotePassThru(ctx context.Context, w io.Writer, remote
 	if err := wait(&wg, ctx); err != nil {
 		return err
 	}
-
+	finalErr := <-errCh
 	close(errCh)
-	return <-errCh
+	return finalErr
 }
 
 func (a *Client) Close() {

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -151,3 +151,22 @@ func TestContextCancelDownload(t *testing.T) {
 		t.Errorf("Expected a canceled error but transfer succeeded without error")
 	}
 }
+
+func TestDownloadBadLocalFilePermissions(t *testing.T) {
+	client := establishConnection(t)
+	defer client.Close()
+
+	// Create a file with local bad permissions
+	// This happens only on Linux
+	f, err := os.OpenFile("./tmp/output.txt", os.O_CREATE, 0644)
+	if err != nil {
+		t.Error("Couldn't open the output file", err.Error())
+	}
+	defer f.Close()
+
+	// This should not timeout and throw an error
+	err = client.CopyFromRemote(context.Background(), f, "/input/Exöt1ç download file.txt.txt")
+	if err == nil {
+		t.Errorf("Expected error thrown. Got nil")
+	}
+}


### PR DESCRIPTION
While trying to download a file from an remote endpoint, I gave the wrong flags to os.Openfile(dstFileName, os.O_CREATE, 0644), thus creating a lock in my code.

Digging in the code, I saw that the scp client was blocking on a write to errCh in CopyFromRemotePassThru. Adding the wg.Done() unblocked the situation.

Maybe related to #54 and #55 

Also, all errors seem to be written twice on errCh as the error is persisted as a variable.