### PR TITLE
Fixed process panics with CopyFromRemotePassThru

### DIFF
--- a/client.go
+++ b/client.go
@@ -243,8 +243,6 @@ func (a *Client) CopyFromRemotePassThru(ctx context.Context, w io.Writer, remote
 		defer func() {
 			// We must unblock the go routine first as we block on reading the channel later
 			wg.Done()
-
-			errCh <- err
 		}()
 
 		r, err := a.Session.StdoutPipe()


### PR DESCRIPTION
Downloading files remotely using CopyFromRemotePassThru may cause the process to panic.
This bug is not always reproducible.

The error is sent to channel immediately after `wg.Done`, but if it is sent at this timing, the channel may have been closed.
Since the error is sent in the function that calls defer, we do not think it is necessary to send it again here.