### PR TITLE
fix: Data race in CopyPassThru

### DIFF
--- a/client.go
+++ b/client.go
@@ -143,6 +143,11 @@ func (a *Client) CopyPassThru(ctx context.Context, r io.Reader, remotePath strin
 	if err != nil {
 		return err
 	}
+	w, err := a.Session.StdinPipe()
+	if err != nil {
+		return err
+	}
+	defer w.Close()
 
 	if passThru != nil {
 		r = passThru(r, size)
@@ -157,12 +162,6 @@ func (a *Client) CopyPassThru(ctx context.Context, r io.Reader, remotePath strin
 
 	go func() {
 		defer wg.Done()
-		w, err := a.Session.StdinPipe()
-		if err != nil {
-			errCh <- err
-			return
-		}
-
 		defer w.Close()
 
 		_, err = fmt.Fprintln(w, "C"+permissions, size, filename)


### PR DESCRIPTION
The fix in #38 was incomplete as it only moved StdoutPipe outside the
goroutine, this commit also moves StdinPipe outside the goroutine so
there is no race when doing Run on the session.

Fixes #39
Related to #38
