### PR TITLE
Implements multi-file upload and download

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,11 +30,8 @@ type Client struct {
 	// ClientConfig the client config to use.
 	ClientConfig *ssh.ClientConfig
 
-	// Keep the ssh client around for generating new sessions on upload/download
+	// Keep the ssh client around for generating new sessions
 	sshClient *ssh.Client
-
-	// Conn stores the SSH connection itself in order to close it after transfer.
-	Conn ssh.Conn
 
 	// Timeout the maximal amount of time to wait for a file transfer to complete.
 	// Deprecated: use context.Context for each function instead.
@@ -52,7 +49,6 @@ func (a *Client) Connect() error {
 	}
 
 	a.sshClient = client
-	a.Conn = client.Conn
 	return nil
 }
 
@@ -134,7 +130,7 @@ func (a *Client) Copy(ctx context.Context, r io.Reader, remotePath string, permi
 func (a *Client) CopyPassThru(ctx context.Context, r io.Reader, remotePath string, permissions string, size int64, passThru PassThru) error {
 	session, err := a.sshClient.NewSession()
 	if err != nil {
-		return fmt.Errorf("Error creating ssh session in copy: %v", err)
+		return fmt.Errorf("Error creating ssh session in copy to remote: %v", err)
 	}
 	defer session.Close()
 
@@ -337,7 +333,7 @@ func (a *Client) CopyFromRemotePassThru(ctx context.Context, w io.Writer, remote
 }
 
 func (a *Client) Close() {
-	if a.Conn != nil {
-		a.Conn.Close()
+	if a.sshClient != nil {
+		a.sshClient.Close()
 	}
 }

--- a/client.go
+++ b/client.go
@@ -134,7 +134,7 @@ func (a *Client) Copy(ctx context.Context, r io.Reader, remotePath string, permi
 func (a *Client) CopyPassThru(ctx context.Context, r io.Reader, remotePath string, permissions string, size int64, passThru PassThru) error {
 	session, err := a.sshClient.NewSession()
 	if err != nil {
-		return fmt.Errorf("Error creating ssh session in copy: ", err)
+		return fmt.Errorf("Error creating ssh session in copy: %v", err)
 	}
 	defer session.Close()
 
@@ -233,7 +233,7 @@ func (a *Client) CopyFromRemote(ctx context.Context, file *os.File, remotePath s
 func (a *Client) CopyFromRemotePassThru(ctx context.Context, w io.Writer, remotePath string, passThru PassThru) error {
 	session, err := a.sshClient.NewSession()
 	if err != nil {
-		return fmt.Errorf("Error creating ssh session in copy from remote: ", err)
+		return fmt.Errorf("Error creating ssh session in copy from remote: %v", err)
 	}
 	defer session.Close()
 

--- a/client.go
+++ b/client.go
@@ -30,8 +30,8 @@ type Client struct {
 	// ClientConfig the client config to use.
 	ClientConfig *ssh.ClientConfig
 
-	// Session stores the SSH session while the connection is running.
-	Session *ssh.Session
+	// Keep the ssh client around for generating new sessions on upload/download
+	sshClient *ssh.Client
 
 	// Conn stores the SSH connection itself in order to close it after transfer.
 	Conn ssh.Conn
@@ -46,20 +46,13 @@ type Client struct {
 
 // Connect connects to the remote SSH server, returns error if it couldn't establish a session to the SSH server.
 func (a *Client) Connect() error {
-	if a.Session != nil {
-		return nil
-	}
-
 	client, err := ssh.Dial("tcp", a.Host, a.ClientConfig)
 	if err != nil {
 		return err
 	}
 
+	a.sshClient = client
 	a.Conn = client.Conn
-	a.Session, err = client.NewSession()
-	if err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -139,11 +132,17 @@ func (a *Client) Copy(ctx context.Context, r io.Reader, remotePath string, permi
 // CopyPassThru copies the contents of an io.Reader to a remote location.
 // Access copied bytes by providing a PassThru reader factory
 func (a *Client) CopyPassThru(ctx context.Context, r io.Reader, remotePath string, permissions string, size int64, passThru PassThru) error {
-	stdout, err := a.Session.StdoutPipe()
+	session, err := a.sshClient.NewSession()
+	if err != nil {
+		return fmt.Errorf("Error creating ssh session in copy: ", err)
+	}
+	defer session.Close()
+
+	stdout, err := session.StdoutPipe()
 	if err != nil {
 		return err
 	}
-	w, err := a.Session.StdinPipe()
+	w, err := session.StdinPipe()
 	if err != nil {
 		return err
 	}
@@ -195,7 +194,7 @@ func (a *Client) CopyPassThru(ctx context.Context, r io.Reader, remotePath strin
 
 	go func() {
 		defer wg.Done()
-		err := a.Session.Run(fmt.Sprintf("%s -qt %q", a.RemoteBinary, remotePath))
+		err := session.Start(fmt.Sprintf("%s -qt %q", a.RemoteBinary, remotePath))
 		if err != nil {
 			errCh <- err
 			return
@@ -232,6 +231,12 @@ func (a *Client) CopyFromRemote(ctx context.Context, file *os.File, remotePath s
 // to keep track of progress and how many bytes that were download from the remote.
 // `passThru` can be set to nil to disable this behaviour.
 func (a *Client) CopyFromRemotePassThru(ctx context.Context, w io.Writer, remotePath string, passThru PassThru) error {
+	session, err := a.sshClient.NewSession()
+	if err != nil {
+		return fmt.Errorf("Error creating ssh session in copy from remote: ", err)
+	}
+	defer session.Close()
+
 	wg := sync.WaitGroup{}
 	errCh := make(chan error, 4)
 
@@ -247,20 +252,20 @@ func (a *Client) CopyFromRemotePassThru(ctx context.Context, w io.Writer, remote
 
 		}()
 
-		r, err := a.Session.StdoutPipe()
+		r, err := session.StdoutPipe()
 		if err != nil {
 			errCh <- err
 			return
 		}
 
-		in, err := a.Session.StdinPipe()
+		in, err := session.StdinPipe()
 		if err != nil {
 			errCh <- err
 			return
 		}
 		defer in.Close()
 
-		err = a.Session.Start(fmt.Sprintf("%s -f %q", a.RemoteBinary, remotePath))
+		err = session.Start(fmt.Sprintf("%s -f %q", a.RemoteBinary, remotePath))
 		if err != nil {
 			errCh <- err
 			return
@@ -310,7 +315,7 @@ func (a *Client) CopyFromRemotePassThru(ctx context.Context, w io.Writer, remote
 			return
 		}
 
-		err = a.Session.Wait()
+		err = session.Wait()
 		if err != nil {
 			errCh <- err
 			return
@@ -332,9 +337,6 @@ func (a *Client) CopyFromRemotePassThru(ctx context.Context, w io.Writer, remote
 }
 
 func (a *Client) Close() {
-	if a.Session != nil {
-		a.Session.Close()
-	}
 	if a.Conn != nil {
 		a.Conn.Close()
 	}

--- a/configurer.go
+++ b/configurer.go
@@ -77,6 +77,5 @@ func (c *ClientConfigurer) Create() Client {
 		ClientConfig: c.clientConfig,
 		Timeout:      c.timeout,
 		RemoteBinary: c.remoteBinary,
-		Session:      c.session,
 	}
 }

--- a/configurer.go
+++ b/configurer.go
@@ -20,6 +20,7 @@ type ClientConfigurer struct {
 	session      *ssh.Session
 	timeout      time.Duration
 	remoteBinary string
+	sshClient    *ssh.Client
 }
 
 // NewConfigurer creates a new client configurer.
@@ -64,9 +65,8 @@ func (c *ClientConfigurer) ClientConfig(config *ssh.ClientConfig) *ClientConfigu
 	return c
 }
 
-// Session alters the ssh.Session.
-func (c *ClientConfigurer) Session(session *ssh.Session) *ClientConfigurer {
-	c.session = session
+func (c *ClientConfigurer) SSHClient(sshClient *ssh.Client) *ClientConfigurer {
+	c.sshClient = sshClient
 	return c
 }
 
@@ -77,5 +77,6 @@ func (c *ClientConfigurer) Create() Client {
 		ClientConfig: c.clientConfig,
 		Timeout:      c.timeout,
 		RemoteBinary: c.remoteBinary,
+		sshClient:    c.sshClient,
 	}
 }

--- a/scp.go
+++ b/scp.go
@@ -27,19 +27,11 @@ func NewClientWithTimeout(host string, config *ssh.ClientConfig, timeout time.Du
 
 // NewClientBySSH returns a new scp.Client using an already existing established SSH connection.
 func NewClientBySSH(ssh *ssh.Client) (Client, error) {
-	session, err := ssh.NewSession()
-	if err != nil {
-		return Client{}, err
-	}
-	return NewConfigurer("", nil).Session(session).Create(), nil
+	return NewConfigurer("", nil).SSHClient(ssh).Create(), nil
 }
 
 // NewClientBySSHWithTimeout same as NewClientWithTimeout but uses an existing SSH client.
 // Deprecated: provide meaningful context to each "Copy*" function instead.
 func NewClientBySSHWithTimeout(ssh *ssh.Client, timeout time.Duration) (Client, error) {
-	session, err := ssh.NewSession()
-	if err != nil {
-		return Client{}, err
-	}
-	return NewConfigurer("", nil).Session(session).Timeout(timeout).Create(), nil
+	return NewConfigurer("", nil).SSHClient(ssh).Timeout(timeout).Create(), nil
 }

--- a/tests/data/another_file.txt
+++ b/tests/data/another_file.txt
@@ -1,0 +1,2 @@
+Here is some stuff and things.
+Even another line.


### PR DESCRIPTION
This PR affects the following two issues tracked relating to multi-file upload/download in an ssh session. I implemented a similar approach to qcha0 (you'll have to take it on faith that this is my own independent work, but I was obviously influenced by some of their design decisions). However, since they don't seem to have been active for some time, I decided to go ahead and submit a PR for this. I have been using your go library (thank you by the way for implementing this great tool!) in one of my projects, and it would be very nice to have this feature as it simplifies my project's implementation significantly.  The change mainly consists of just creating a new session with the ssh client each time you upload/download a file rather than keeping around the ssh session for the lifetime of the struct.

I added a test that uploads two files and downloads them subsequently to your tests folder, but I can add a couple more depending on what other edge cases I should cover.

This PR should close both issues #59 and #60 in your issue tracking.

Let me know if you need me to change anything or add anymore test coverage. 

Thanks!