### PR TITLE
Handle T message and prepare for adding -p option

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -9,103 +9,96 @@ package scp
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"io"
 	"strconv"
 	"strings"
 )
 
-type ResponseType = uint8
+type ResponseType = byte
 
 const (
 	Ok      ResponseType = 0
 	Warning ResponseType = 1
 	Error   ResponseType = 2
+	Create  ResponseType = 'C'
+	Time    ResponseType = 'T'
 )
-
-type ProtocolType = rune
-
-const (
-	Chmod ProtocolType = 'C'
-	Time  ProtocolType = 'T'
-)
-
-// Response represent a response from the SCP command.
-// There are tree types of responses that the remote can send back:
-// ok, warning and error
-//
-// The difference between warning and error is that the connection is not closed by the remote,
-// however, a warning can indicate a file transfer failure (such as invalid destination directory)
-// and such be handled as such.
-//
-// All responses except for the `Ok` type always have a message (although these can be empty)
-//
-// The remote sends a confirmation after every SCP command, because a failure can occur after every
-// command, the response should be read and checked after sending them.
-type Response struct {
-	Type         ResponseType
-	Message      string
-	ProtocolType rune
-}
 
 // ParseResponse reads from the given reader (assuming it is the output of the remote) and parses it into a Response structure.
-func ParseResponse(reader io.Reader) (Response, error) {
+func ParseResponse(reader io.Reader, writer io.Writer) (*FileInfos, error) {
+	fileInfos := NewFileInfos()
+
 	buffer := make([]uint8, 1)
 	_, err := reader.Read(buffer)
 	if err != nil {
-		return Response{}, err
+		return fileInfos, err
 	}
 
 	responseType := buffer[0]
-	runeResponseType := rune(buffer[0])
 	message := ""
 	if responseType > 0 {
 		bufferedReader := bufio.NewReader(reader)
 		message, err = bufferedReader.ReadString('\n')
 		if err != nil {
-			return Response{}, err
+			return fileInfos, err
+		}
+
+		if responseType == Warning || responseType == Error {
+			return fileInfos, errors.New(
+				fmt.Sprintf("Failed to execute command with a warning or error: %s", message),
+			)
+		}
+
+		// Exit early because we're only interested in the ok response
+		if responseType == Ok {
+			return fileInfos, nil
+		}
+
+		if !(responseType == Create || responseType == Time) {
+			return fileInfos, errors.New(
+				fmt.Sprintf(
+					"Message does not follow scp protocol: %s\n Cmmmm <length> <filename> or T<mtime> 0 <atime> 0",
+					message,
+				),
+			)
+		}
+
+		if responseType == Time {
+			err = ParseFileTime(message, fileInfos)
+			if err != nil {
+				return nil, err
+			}
+
+			message, err = bufferedReader.ReadString('\n')
+			if err == io.EOF {
+				err = Ack(writer)
+				if err != nil {
+					return fileInfos, err
+				}
+				message, err = bufferedReader.ReadString('\n')
+
+				if err != nil {
+					return fileInfos, err
+				}
+			}
+
+			if err != nil && err != io.EOF {
+				return fileInfos, err
+			}
+
+			responseType = message[0]
+		}
+
+		if responseType == Create {
+			err = ParseFileInfos(message, fileInfos)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
-	if len(message) > 0 {
-		return Response{responseType, message, runeResponseType}, nil
-	}
-
-	return Response{responseType, message, ' '}, nil
-}
-
-func (r *Response) IsOk() bool {
-	return r.Type == Ok
-}
-
-func (r *Response) IsWarning() bool {
-	return r.Type == Warning
-}
-
-// IsError returns true when the remote responded with an error.
-func (r *Response) IsError() bool {
-	return r.Type == Error
-}
-
-// IsFailure returns true when the remote answered with a warning or an error.
-func (r *Response) IsFailure() bool {
-	return r.IsWarning() || r.IsError()
-}
-
-func (r *Response) IsChmod() bool {
-	return r.ProtocolType == Chmod
-}
-
-func (r *Response) IsTime() bool {
-	return r.ProtocolType == Time
-}
-
-func (r *Response) NoStandardProtocolType() bool {
-	return !(r.ProtocolType == Chmod || r.ProtocolType == Time)
-}
-
-// GetMessage returns the message the remote sent back.
-func (r *Response) GetMessage() string {
-	return r.Message
+	return fileInfos, nil
 }
 
 type FileInfos struct {
@@ -142,47 +135,51 @@ func (fileInfos *FileInfos) Update(new *FileInfos) {
 	}
 }
 
-func (r *Response) ParseFileInfos() (*FileInfos, error) {
-	message := strings.ReplaceAll(r.Message, "\n", "")
-	parts := strings.Split(message, " ")
+func ParseFileInfos(message string, fileInfos *FileInfos) error {
+	processMessage := strings.ReplaceAll(message, "\n", "")
+	parts := strings.Split(processMessage, " ")
 	if len(parts) < 3 {
-		return nil, errors.New("unable to parse Chmod protocol")
+		return errors.New("unable to parse Chmod protocol")
 	}
 
 	size, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return &FileInfos{
-		Message:     r.Message,
+	fileInfos.Update(&FileInfos{
+		Filename:    parts[2],
 		Permissions: parts[0],
 		Size:        int64(size),
-		Filename:    parts[2],
-	}, nil
+	})
+
+	return nil
 }
 
-func (r *Response) ParseFileTime() (*FileInfos, error) {
-	message := strings.ReplaceAll(r.Message, "\n", "")
-	parts := strings.Split(message, " ")
+func ParseFileTime(
+	message string,
+	fileInfos *FileInfos,
+) error {
+	processMessage := strings.ReplaceAll(message, "\n", "")
+	parts := strings.Split(processMessage, " ")
 	if len(parts) < 3 {
-		return nil, errors.New("unable to parse Time protocol")
+		return errors.New("unable to parse Time protocol")
 	}
 
 	aTime, err := strconv.Atoi(string(parts[0][0:10]))
 	if err != nil {
-		return nil, errors.New("unable to parse ATime component of message")
+		return errors.New("unable to parse ATime component of message")
 	}
 	mTime, err := strconv.Atoi(string(parts[2][0:10]))
 	if err != nil {
-		return nil, errors.New("unable to parse MTime component of message")
+		return errors.New("unable to parse MTime component of message")
 	}
 
-	return &FileInfos{
-		Message: r.Message,
-		Atime:   int64(aTime),
-		Mtime:   int64(mTime),
-	}, nil
+	fileInfos.Update(&FileInfos{
+		Atime: int64(aTime),
+		Mtime: int64(mTime),
+	})
+	return nil
 }
 
 // Ack writes an `Ack` message to the remote, does not await its response, a seperate call to ParseResponse is

--- a/protocol.go
+++ b/protocol.go
@@ -56,8 +56,9 @@ func ParseResponse(reader io.Reader) (Response, error) {
 	}
 
 	responseType := buffer[0]
+	runeResponseType := rune(buffer[0])
 	message := ""
-	if responseType > 0 {
+	if responseType > 0 && (runeResponseType == Chmod || runeResponseType == Time) {
 		bufferedReader := bufio.NewReader(reader)
 		message, err = bufferedReader.ReadString('\n')
 		if err != nil {
@@ -66,7 +67,7 @@ func ParseResponse(reader io.Reader) (Response, error) {
 	}
 
 	if len(message) > 0 {
-		return Response{responseType, message, rune(message[0])}, nil
+		return Response{responseType, message, runeResponseType}, nil
 	}
 
 	return Response{responseType, message, ' '}, nil

--- a/protocol.go
+++ b/protocol.go
@@ -117,6 +117,10 @@ type FileInfos struct {
 	Mtime       int64
 }
 
+func NewFileInfos() *FileInfos {
+	return &FileInfos{}
+}
+
 func (fileInfos *FileInfos) Update(new *FileInfos) {
 	if new == nil {
 		return

--- a/protocol.go
+++ b/protocol.go
@@ -58,7 +58,7 @@ func ParseResponse(reader io.Reader) (Response, error) {
 	responseType := buffer[0]
 	runeResponseType := rune(buffer[0])
 	message := ""
-	if responseType > 0 && (runeResponseType == Chmod || runeResponseType == Time) {
+	if responseType > 0 {
 		bufferedReader := bufio.NewReader(reader)
 		message, err = bufferedReader.ReadString('\n')
 		if err != nil {

--- a/protocol.go
+++ b/protocol.go
@@ -45,9 +45,7 @@ func ParseResponse(reader io.Reader, writer io.Writer) (*FileInfos, error) {
 		}
 
 		if responseType == Warning || responseType == Error {
-			return fileInfos, errors.New(
-				fmt.Sprintf("Failed to execute command with a warning or error: %s", message),
-			)
+			return fileInfos, errors.New(message)
 		}
 
 		// Exit early because we're only interested in the ok response

--- a/protocol.go
+++ b/protocol.go
@@ -169,7 +169,7 @@ func (r *Response) ParseFileTime() (*FileInfos, error) {
 		return nil, errors.New("unable to parse Time protocol")
 	}
 
-	aTime, err := strconv.Atoi(string(parts[0][1:10]))
+	aTime, err := strconv.Atoi(string(parts[0][0:10]))
 	if err != nil {
 		return nil, errors.New("unable to parse ATime component of message")
 	}


### PR DESCRIPTION
In protocol.go I added a new field to the Response struct, indicating the type of Protocol. I believe this will prepare us to handle also -d in the future, but for the moment, the goal is to prepare for -p requests.

When parsing the message, I also make sure that the protocol is being followed, as SCP doesn't allow any other messages besides the ones starting with C, T, D.
![image](https://github.com/bramvdbogaerde/go-scp/assets/16731794/aff84892-45b4-458b-a383-0dc803cff64b)

I also added some new methods to check which type of protocol it is and if it is following the protocol. Of course if we get any directory response, it will throw an error saying it doesn't follow protocol, but that would a problem with a custom server sending this information because we don't have methods requesting that yet.

Finally, I added a method for parsing the time components. The length of the number is always from 0:10, so it should throw an error if that is not the case.


In client.go, I modified the client so when we get time information, then we make sure it doesn't impact the flow. What I encountered with a custom ssh server is that, even though I sent only -f, I would receive the time and that would cause an EOF error, as I was asking for more to read than there was on the server.

In this current form, then the time is stored in an object and it will throw an error only if the custom server sends an malformed T message, but then again, there are issues in the custom ssh server.

I prepared the FilesInfo object to use that later on as output for our -p request. For now it's "dead code" as it's not used, but I didn't want to stuff too much in the pull request.

I have tested on a custom ssh server, with the localhost OpenSSH server and using the tests in the repository.