### PR TITLE
Implement preserve

### DIFF
--- a/client.go
+++ b/client.go
@@ -315,7 +315,7 @@ func (a *Client) CopyFromRemotePassThru(
 	remotePath string,
 	passThru PassThru,
 ) error {
-	_, err := a.copyFromRemoteFunctionality(ctx, w, remotePath, passThru, false)
+	_, err := a.copyFromRemote(ctx, w, remotePath, passThru, false)
 
 	return err
 }
@@ -328,10 +328,10 @@ func (a *Client) CopyFromRemoteFileInfos(
 	remotePath string,
 	passThru PassThru,
 ) (*FileInfos, error) {
-	return a.copyFromRemoteFunctionality(ctx, w, remotePath, passThru, true)
+	return a.copyFromRemote(ctx, w, remotePath, passThru, true)
 }
 
-func (a *Client) copyFromRemoteFunctionality(
+func (a *Client) copyFromRemote(
 	ctx context.Context,
 	w io.Writer,
 	remotePath string,

--- a/client.go
+++ b/client.go
@@ -339,7 +339,7 @@ func (a *Client) CopyFromRemoteFileInfos(
 
 	wg := sync.WaitGroup{}
 	errCh := make(chan error, 4)
-	fileInfosCh := make(chan *FileInfos, 1)
+	fileInfosCh := make(chan *FileInfos, 4)
 
 	wg.Add(1)
 	go func() {
@@ -395,11 +395,12 @@ func (a *Client) CopyFromRemoteFileInfos(
 
 		if fileInfo != nil {
 			fileInfosCh <- fileInfo
+		} else {
+			fileInfosCh <- nil
 		}
 
 		err = Ack(in)
 		if err != nil {
-			fileInfosCh <- nil
 			errCh <- err
 			return
 		}
@@ -410,21 +411,18 @@ func (a *Client) CopyFromRemoteFileInfos(
 
 		_, err = CopyN(w, r, fileInfo.Size)
 		if err != nil {
-			fileInfosCh <- nil
 			errCh <- err
 			return
 		}
 
 		err = Ack(in)
 		if err != nil {
-			fileInfosCh <- nil
 			errCh <- err
 			return
 		}
 
 		err = session.Wait()
 		if err != nil {
-			fileInfosCh <- nil
 			errCh <- err
 			return
 		}

--- a/configurer.go
+++ b/configurer.go
@@ -21,6 +21,7 @@ type ClientConfigurer struct {
 	timeout      time.Duration
 	remoteBinary string
 	sshClient    *ssh.Client
+	preserve     bool
 }
 
 // NewConfigurer creates a new client configurer.
@@ -36,6 +37,7 @@ func NewConfigurer(host string, config *ssh.ClientConfig) *ClientConfigurer {
 		clientConfig: config,
 		timeout:      0, // no timeout by default
 		remoteBinary: "scp",
+		preserve:     false,
 	}
 }
 
@@ -70,6 +72,13 @@ func (c *ClientConfigurer) SSHClient(sshClient *ssh.Client) *ClientConfigurer {
 	return c
 }
 
+// Preserve alters the preserve flag
+// Defaults to false
+func (c *ClientConfigurer) Preserve(preserve bool) *ClientConfigurer {
+	c.preserve = preserve
+	return c
+}
+
 // Create builds a client with the configuration stored within the ClientConfigurer.
 func (c *ClientConfigurer) Create() Client {
 	return Client{
@@ -78,6 +87,7 @@ func (c *ClientConfigurer) Create() Client {
 		Timeout:      c.timeout,
 		RemoteBinary: c.remoteBinary,
 		sshClient:    c.sshClient,
-                closeHandler: EmptyHandler{},
+		preserve:     c.preserve,
+		closeHandler: EmptyHandler{},
 	}
 }

--- a/configurer.go
+++ b/configurer.go
@@ -21,7 +21,6 @@ type ClientConfigurer struct {
 	timeout      time.Duration
 	remoteBinary string
 	sshClient    *ssh.Client
-	preserve     bool
 }
 
 // NewConfigurer creates a new client configurer.
@@ -37,7 +36,6 @@ func NewConfigurer(host string, config *ssh.ClientConfig) *ClientConfigurer {
 		clientConfig: config,
 		timeout:      0, // no timeout by default
 		remoteBinary: "scp",
-		preserve:     false,
 	}
 }
 
@@ -72,13 +70,6 @@ func (c *ClientConfigurer) SSHClient(sshClient *ssh.Client) *ClientConfigurer {
 	return c
 }
 
-// Preserve alters the preserve flag
-// Defaults to false
-func (c *ClientConfigurer) Preserve(preserve bool) *ClientConfigurer {
-	c.preserve = preserve
-	return c
-}
-
 // Create builds a client with the configuration stored within the ClientConfigurer.
 func (c *ClientConfigurer) Create() Client {
 	return Client{
@@ -87,7 +78,6 @@ func (c *ClientConfigurer) Create() Client {
 		Timeout:      c.timeout,
 		RemoteBinary: c.remoteBinary,
 		sshClient:    c.sshClient,
-		preserve:     c.preserve,
 		closeHandler: EmptyHandler{},
 	}
 }

--- a/protocol.go
+++ b/protocol.go
@@ -136,7 +136,7 @@ func ParseFileInfos(message string, fileInfos *FileInfos) error {
 		return errors.New("unable to parse Chmod protocol")
 	}
 
-	permissions, err := strconv.ParseUint(parts[0][1:5], 0, 32)
+	permissions, err := strconv.ParseUint(parts[0][1:], 0, 32)
 	if err != nil {
 		return err
 	}

--- a/protocol.go
+++ b/protocol.go
@@ -98,7 +98,7 @@ func ParseResponse(reader io.Reader, writer io.Writer) (*FileInfos, error) {
 type FileInfos struct {
 	Message     string
 	Filename    string
-	Permissions string
+	Permissions uint32
 	Size        int64
 	Atime       int64
 	Mtime       int64
@@ -115,7 +115,7 @@ func (fileInfos *FileInfos) Update(new *FileInfos) {
 	if new.Filename != "" {
 		fileInfos.Filename = new.Filename
 	}
-	if new.Permissions != "" {
+	if new.Permissions != 0 {
 		fileInfos.Permissions = new.Permissions
 	}
 	if new.Size != 0 {
@@ -136,6 +136,11 @@ func ParseFileInfos(message string, fileInfos *FileInfos) error {
 		return errors.New("unable to parse Chmod protocol")
 	}
 
+	permissions, err := strconv.ParseUint(parts[0][1:5], 0, 32)
+	if err != nil {
+		return err
+	}
+
 	size, err := strconv.Atoi(parts[1])
 	if err != nil {
 		return err
@@ -143,7 +148,7 @@ func ParseFileInfos(message string, fileInfos *FileInfos) error {
 
 	fileInfos.Update(&FileInfos{
 		Filename:    parts[2],
-		Permissions: parts[0],
+		Permissions: uint32(permissions),
 		Size:        int64(size),
 	})
 
@@ -164,7 +169,7 @@ func ParseFileTime(
 	if err != nil {
 		return errors.New("unable to parse ATime component of message")
 	}
-	mTime, err := strconv.Atoi(string(parts[2][0:10]))
+	mTime, err := strconv.ParseUint(string(parts[2][0:10]), 0, 32)
 	if err != nil {
 		return errors.New("unable to parse MTime component of message")
 	}

--- a/protocol.go
+++ b/protocol.go
@@ -68,20 +68,16 @@ func ParseResponse(reader io.Reader, writer io.Writer) (*FileInfos, error) {
 				return nil, err
 			}
 
-			message, err = bufferedReader.ReadString('\n')
-			if err == io.EOF {
+			if bufferedReader.Buffered() == 0 {
 				err = Ack(writer)
-				if err != nil {
-					return fileInfos, err
-				}
-				message, err = bufferedReader.ReadString('\n')
-
 				if err != nil {
 					return fileInfos, err
 				}
 			}
 
-			if err != nil && err != io.EOF {
+			message, err = bufferedReader.ReadString('\n')
+
+			if err != nil {
 				return fileInfos, err
 			}
 

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -279,12 +279,20 @@ func TestDownloadFileInfo(t *testing.T) {
 		t.Errorf("File size does not match")
 	}
 
-	if fs.FileMode(fileInfos.Permissions) == fileStat.Mode().Perm() {
-		t.Errorf("File permissions don't match")
+	if fs.FileMode(fileInfos.Permissions) == fs.FileMode(0777) {
+		t.Errorf(
+			"File permissions don't match %s vs %s",
+			fs.FileMode(fileInfos.Permissions),
+			fileStat.Mode().Perm(),
+		)
 	}
 
 	if fileInfos.Mtime != fileStat.ModTime().Unix() {
-		t.Errorf("File modification time does not match")
+		t.Errorf(
+			"File modification time does not match %d vs %d",
+			fileInfos.Mtime,
+			fileStat.ModTime().Unix(),
+		)
 	}
 }
 

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -235,10 +235,6 @@ func TestDownloadFile(t *testing.T) {
 	client := establishConnection(t)
 	defer client.Close()
 
-	// Open a file we can transfer to the remote container.
-	f, _ := os.Open("./data/input.txt")
-	defer f.Close()
-
 	// Create a local file to write to.
 	f, err := os.OpenFile("./tmp/output.txt", os.O_RDWR|os.O_CREATE, 0777)
 	if err != nil {

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -270,7 +270,7 @@ func TestDownloadFileInfo(t *testing.T) {
 		t.Errorf("Got different text than expected, expected %q got, %q", expected, text)
 	}
 
-	fileStat, err := os.Stat("/input/Exöt1ç download file.txt.txt")
+	fileStat, err := os.Stat("./data/Exöt1ç download file.txt.txt")
 	if err != nil {
 		t.Errorf("Result file could not be read: %s", err)
 	}

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -310,6 +310,18 @@ func TestDownloadFileInfo(t *testing.T) {
 		t.Errorf("File size does not match")
 	}
 
+	if fileInfos.Mtime == 0 {
+		t.Errorf("No file mtime preserved")
+	}
+
+	if fileInfos.Atime == 0 {
+		t.Errorf("No file atime preserved")
+	}
+
+	if fileInfos.Permissions == 0 {
+		t.Errorf("No file permissions preserved")
+	}
+
 }
 
 // TestTimeoutDownload tests that a timeout error is produced if the file is not copied in the given


### PR DESCRIPTION
protocol.go had a bug. Checking if the buffer had more information was not implemented correctly, but it wasn't affecting current functionality. Now that -p is added, I could see the bug. I replaced the check for io.eof with a check if there is any data left buffered.

I added in the configurer the option to have the preserve field set to true through the Preserve method.

To update the signature with a return value, I create a new method linked to client. If there is an error and the user tries to use the FileInfos object, then they will get a null pointer. I think that makes it more obvious that they didn't check the error.

I also added a test for the -p functionality, but I think I might need more to cover it better. I'm not sure exactly how to test that the FileInfo has the right time in atime and mtime, as the file is create in the docker container by cloning the repo, so I don't know if the file information is preserved.

I'm open to suggestions and comments 😄.

I think the tests are lacking and I plan to write more before we merge.


