### PR TITLE
Fix: Use strconv.ParseInt for 64-bit values on 32-bit systems

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -144,7 +144,7 @@ func ParseFileInfos(message string, fileInfos *FileInfos) error {
 		return err
 	}
 
-	size, err := strconv.Atoi(parts[1])
+	size, err := strconv.ParseInt(parts[1], 10, 64)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes issue #86 by swapping `strconv.Atoi` with `strconv.ParseInt` to handle large file sizes correctly on 32-bit systems. No testing is really needed, but I can confirm that the old code using Atoi would fail for a file size such as ~5-6 GiB, with the update supporting way larger files (tested with a 21 GiB file).